### PR TITLE
Automatically determine the client version to use

### DIFF
--- a/run.py
+++ b/run.py
@@ -13,7 +13,7 @@ def run(config_path):
         config = json.load(file)
 
     # Docker API client
-    client = docker.from_env()
+    client = docker.from_env(version="auto")
 
     # Remove any existing image
     remove_existing(client, config)


### PR DESCRIPTION
By default the client uses its version as the server version and API calls will fail in a mismatch. The client can automatically downgrade its version to the server version, however, if the client is newer than the server (as is the setup on `tuna`).

@lintool @paopao74cn 

https://docker-py.readthedocs.io/en/stable/client.html