### PR TITLE
Restart container after setting up the indexes

### DIFF
--- a/run.py
+++ b/run.py
@@ -40,6 +40,9 @@ def run(config_path):
                                             os.path.join("/opt/solr/server/solr/mycores", index["name"], "data/index")),
                            user='solr')
 
+    # Restart the container (and thus Solr) to load the indexes.
+    container.restart()
+
 
 # Remove any existing containers
 def remove_existing(client, config):


### PR DESCRIPTION
Restarting the container after setting up the indexes lets Solr load the
indexes properly, this seems to work better than using the RELOAD REST
API call.